### PR TITLE
envの形式を正しいものにした

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
-watson_iam_apikey: 
-watson_workspace_id: 
+WATSON_IAM_APIKEY= 
+WATSON_WORKSPACE_ID=
+
+LINEBOT_CHANNEL_SECRET=
+LINEBOT_CHANNEL_TOKEN=

--- a/modules/client/linebot/linebot.go
+++ b/modules/client/linebot/linebot.go
@@ -16,8 +16,8 @@ import (
 func ExecuteProcess(c echo.Context) error {
 
 	bot, err := linebot.New(
-		os.Getenv("linebot_channel_secret"),
-		os.Getenv("linebot_channel_token"),
+		os.Getenv("LINEBOT_CHANNEL_SECRET"),
+		os.Getenv("LINEBOT_CHANNEL_TOKEN"),
 	)
 	if err != nil {
 		fmt.Println("Initialize Error:", err)

--- a/modules/logic/request_ai.go
+++ b/modules/logic/request_ai.go
@@ -21,7 +21,7 @@ type ReplyAIType struct {
 // RequestAI : AIに向けてリクエストを送るところ。今回はWatson Assistantを使用
 func RequestAI(reqMessage string) (*watsonResType.WatsonResponseType, error) {
 	authenticator := &core.IamAuthenticator{
-		ApiKey: os.Getenv("watson_iam_apikey"),
+		ApiKey: os.Getenv("WATSON_IAM_APIKEY"),
 	}
 
 	service, serviceErr := assistant.NewAssistantV1(&assistant.AssistantV1Options{


### PR DESCRIPTION
## なぜやるのか
* goで`.env`の使い方を調べた時の書き方に遵守してやったんだけど、なんかいろいろ変わってた

## 注意点
* https://github.com/tlab-pss/PartnerAssistant/pull/10 をマージしてからマージする